### PR TITLE
Update README format per feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,74 @@
 # PromptSmith
 
-<img src="assets/promptsmith.png" width="200" />  
+![PromptSmith logo](assets/promptsmith.png)
 
-**PromptSmith** is a workbench for crafting and stress‑testing prompts (and their judges) for large‑language models.
+**PromptSmith** is a small workbench built with [DSPy](https://github.com/stanfordnlp/dspy) for experimenting with prompt engineering and custom evaluation judges. It provides a few text‑transformation tasks, scoring modules, and a self‑refinement loop to iteratively improve LLM outputs.
 
-## What it does
+## Features
 
-1. **Forge prompts** – Write the instruction you need for any task (text restructuring, bullying detection, anything).
-2. **Add judges** – Describe what "good" looks like; PromptSmith turns that into an automatic score.
-3. **Auto‑tune** – DSPy iterates, scoring and refining until your prompt is rock‑solid.
+- **Tasks** – sample DSPy `Signature`s for rewriting text such as `BulletizeText` and `RestructureText`.
+- **Judges** – evaluation modules (e.g. `JudgeMeaning`, `JudgeCoverage`, `JudgeBulletStructure`) that score an output against the original input.
+- **Ensemble judging** – YAML configs combine multiple judges with weights to produce a single verdict.
+- **Refinement loop** – the `RefinementOrchestrator` runs a task, evaluates it and asks a refiner module to fix the worst aspect until a target score is met.
+- **Streamlit apps** – `app.py` exposes the tasks and judges in a simple web UI. `bullet_battle.py` lets a human compare two versions of bulletised text.
+- **Jupyter notebooks** – examples showing how to use DSPy together with the provided modules.
 
-## Why it matters
+## Setup
 
-LLMs shine only when guided by clear instructions **and** robust evaluation. PromptSmith helps you shape both so your models stay reliable on even the trickiest inputs.
+1. Clone this repository.
+2. Install the dependencies (editable install recommended):
+   ```bash
+   pip install -e .
+   ```
+   or
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Create a `.env` file with your `OPENAI_API_KEY`.
+
+## Usage
+
+### Running the web UI
+
+Launch the main workbench using Streamlit:
+
+```bash
+streamlit run app.py
+```
+
+You can then paste text, choose a task and a judge, and see the transformed output along with structured feedback.
+
+`bullet_battle.py` is a smaller app for manually choosing which of two bulletised versions is better:
+
+```bash
+streamlit run bullet_battle.py
+```
+
+### Using the modules in code
+
+```python
+from promptsmith.dspy_init import get_dspy
+from promptsmith.tasks.bulletize_text import BulletizeText
+from promptsmith.evaluation.task_evaluator import TaskEvaluator
+from promptsmith.judges.ensemble_judge import EnsembleJudge
+
+# initialise DSPy and the language model
+dspy, _ = get_dspy()
+
+# build the task and evaluation pipeline
+task = dspy.ChainOfThought(BulletizeText)
+judge = EnsembleJudge('promptsmith/judges/judge_bulletize_text.yaml')
+evaluator = TaskEvaluator(task=task, judges={"outline": judge})
+
+result = evaluator.evaluate("Long text to summarise ...")
+print(result.scores, result.combined_score)
+```
+
+Consult the notebooks in `notebooks/` for more detailed examples and analysis.
+
+## Contributing
+
+Pull requests are welcome. Feel free to open an issue or submit a PR if you find problems or have ideas for improvements.
+
+LLMs shine only when guided by clear instructions **and** reliable evaluation. PromptSmith helps you craft both so your models stay robust, even on tricky inputs.
+


### PR DESCRIPTION
## Summary
- drop tech stack and license sections from the README
- keep contributing guidelines and add a short closing statement

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686517675238832fa68fe05444c540b7